### PR TITLE
Replace Kernal.open to URI.open

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -95,7 +95,7 @@ module Refile
     # @param [String] id           The id of the file
     # @return [IO]                An IO object containing the file contents
     verify_id def open(id)
-      Kernel.open(object(id).presigned_url(:get))
+      URI.open(object(id).presigned_url(:get))
     end
 
     # Return the entire contents of the uploaded file as a String.


### PR DESCRIPTION
Fix the warning of
`/gems/refile-s3-0.2.0/lib/refile/s3.rb:98: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open`